### PR TITLE
Harden Node app

### DIFF
--- a/todo-list-node/admin/users.js
+++ b/todo-list-node/admin/users.js
@@ -3,7 +3,9 @@ const db = require('../fw/db');
 async function getHtml() {
     let conn = await db.connectDB();
     let html = '';
-    let [result,fields] = await conn.query("SELECT users.ID, users.username, users.password, roles.title FROM users inner join permissions on users.ID = permissions.userID inner join roles on permissions.roleID = roles.ID order by username");
+    let [result] = await conn.execute(
+        'SELECT users.ID, users.username, roles.title FROM users inner join permissions on users.ID = permissions.userID inner join roles on permissions.roleID = roles.ID order by username'
+    );
 
     html += `
     <h2>User List</h2>
@@ -16,7 +18,7 @@ async function getHtml() {
         </tr>`;
 
     result.map(function (record) {
-        html += `<tr><td>`+record.ID+`</td><td>`+record.username+`</td><td>`+record.title+`</td><input type='hidden' name='password' value='`+record.password+`' /></tr>`;
+        html += `<tr><td>`+record.ID+`</td><td>`+record.username+`</td><td>`+record.title+`</td></tr>`;
     });
 
     html += `
@@ -25,4 +27,4 @@ async function getHtml() {
     return html;
 }
 
-module.exports = { html: getHtml() };
+module.exports = { html: getHtml };

--- a/todo-list-node/edit.js
+++ b/todo-list-node/edit.js
@@ -1,4 +1,5 @@
 const db = require('./fw/db');
+const { escapeHtml } = require('./fw/utils');
 
 async function getHtml(req) {
     let title = '';
@@ -13,7 +14,7 @@ async function getHtml(req) {
         console.log(req.query.id);
         taskId = req.query.id;
         let conn = await db.connectDB();
-        let [result, fields] = await conn.query('select ID, title, state from tasks where ID = '+taskId);
+        let [result] = await conn.execute('select ID, title, state from tasks where ID = ?', [taskId]);
         if(result.length > 0) {
             title = result[0].title;
             state = result[0].state;
@@ -29,7 +30,7 @@ async function getHtml(req) {
         <input type="hidden" name="id" value="`+taskId+`" />
         <div class="form-group">
             <label for="title">Description</label>
-            <input type="text" class="form-control size-medium" name="title" id="title" value="`+title+`">
+            <input type="text" class="form-control size-medium" name="title" id="title" value="`+escapeHtml(title)+`">
         </div>
         <div class="form-group">
             <label for="state">State</label>

--- a/todo-list-node/fw/db.js
+++ b/todo-list-node/fw/db.js
@@ -12,10 +12,10 @@ async function connectDB() {
     }
 }
 
-async function executeStatement(statement) {
+async function executeStatement(statement, params = []) {
     let conn = await connectDB();
-    const [results, fields] = await conn.query(statement);
+    const [results] = await conn.execute(statement, params);
     return results;
 }
 
-module.exports = { connectDB: connectDB, executeStatement: executeStatement };
+module.exports = { connectDB, executeStatement };

--- a/todo-list-node/fw/header.js
+++ b/todo-list-node/fw/header.js
@@ -1,5 +1,6 @@
 const login = require('../login');
 const db = require('../fw/db');
+const { escapeHtml } = require('../fw/utils');
 
 async function getHtml(req) {
     let content = `<!DOCTYPE html>
@@ -20,7 +21,10 @@ async function getHtml(req) {
     let roleid = 0;
     if(req.cookies.userid !== undefined && req.cookies.userid !== '') {
         id = req.cookies.userid;
-        let stmt = await db.executeStatement("select users.id userid, roles.id roleid, roles.title rolename from users inner join permissions on users.id = permissions.userid inner join roles on permissions.roleID = roles.id where userid = "+id);
+        let stmt = await db.executeStatement(
+            'select users.id userid, roles.id roleid, roles.title rolename from users inner join permissions on users.id = permissions.userid inner join roles on permissions.roleID = roles.id where userid = ?',
+            [id]
+        );
         console.log(stmt);
 
         // load role from db

--- a/todo-list-node/fw/utils.js
+++ b/todo-list-node/fw/utils.js
@@ -1,0 +1,10 @@
+function escapeHtml(str) {
+  if (!str) return '';
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+module.exports = { escapeHtml };

--- a/todo-list-node/index.js
+++ b/todo-list-node/index.js
@@ -1,9 +1,10 @@
 const tasklist = require('./user/tasklist');
 const bgSearch = require('./user/backgroundsearch');
+const { escapeHtml } = require('./fw/utils');
 
 async function getHtml(req) {
     let taskListHtml = await tasklist.html(req);
-    return `<h2>Welcome, `+req.cookies.username+`!</h2>` + taskListHtml + '<hr />' + bgSearch.html(req);
+    return `<h2>Welcome, ${escapeHtml(req.cookies.username)}!</h2>` + taskListHtml + '<hr />' + bgSearch.html(req);
 }
 
 module.exports = {

--- a/todo-list-node/login.js
+++ b/todo-list-node/login.js
@@ -1,4 +1,5 @@
 const db = require('./fw/db');
+const bcrypt = require('bcrypt');
 const speakeasy = require('speakeasy'); // for MFA
 const { recordFailure, resetAttempts } = require('./fw/bf-protection');
 
@@ -60,8 +61,8 @@ async function handleLogin(req, res) {
 
 function startUserSession(res, user) {
     console.log('Starting session for user', user.userid);
-    res.cookie('username', user.username);
-    res.cookie('userid', user.userid);
+    res.cookie('username', user.username, { httpOnly: true });
+    res.cookie('userid', user.userid, { httpOnly: true });
     res.redirect('/');
 }
 
@@ -78,7 +79,7 @@ async function validateLogin(username, password) {
 
         if (rows.length > 0) {
             const user = rows[0];
-            if (password === user.password) {
+            if (await bcrypt.compare(password, user.password)) {
                 result.valid      = true;
                 result.userId     = user.id;
                 result.msg        = 'login correct';

--- a/todo-list-node/savetask.js
+++ b/todo-list-node/savetask.js
@@ -7,7 +7,7 @@ async function getHtml(req) {
     // see if the id exists in the database
     if (req.body.id !== undefined && req.body.id.length !== 0) {
         taskId = req.body.id;
-        let stmt = await db.executeStatement('select ID, title, state from tasks where ID = ' + taskId);
+        let stmt = await db.executeStatement('select ID, title, state from tasks where ID = ?', [taskId]);
         if (stmt.length === 0) {
             taskId = '';
         }
@@ -19,9 +19,9 @@ async function getHtml(req) {
         let userid = req.cookies.userid;
 
         if (taskId === ''){
-            stmt = db.executeStatement("insert into tasks (title, state, userID) values ('"+title+"', '"+state+"', '"+userid+"')");
+            stmt = db.executeStatement('insert into tasks (title, state, userID) values (?, ?, ?)', [title, state, userid]);
         } else {
-            stmt = db.executeStatement("update tasks set title = '"+title+"', state = '"+state+"' where ID = "+taskId);
+            stmt = db.executeStatement('update tasks set title = ?, state = ? where ID = ?', [title, state, taskId]);
         }
 
         html += "<span class='info info-success'>Update successfull</span>";

--- a/todo-list-node/search.js
+++ b/todo-list-node/search.js
@@ -7,6 +7,9 @@ async function getHtml(req) {
     }
 
     let provider = req.body.provider;
+    if (!provider.startsWith('/search/v2/')) {
+        return 'Invalid provider';
+    }
     let terms = req.body.terms;
     let userid = req.body.userid;
 

--- a/todo-list-node/search/v2/index.js
+++ b/todo-list-node/search/v2/index.js
@@ -1,4 +1,5 @@
 const db = require('../../fw/db');
+const { escapeHtml } = require('../../fw/utils');
 
 async function search(req) {
     if (req.query.userid === undefined || req.query.terms === undefined){
@@ -9,10 +10,13 @@ async function search(req) {
     let terms = req.query.terms;
     let result = '';
 
-    let stmt = await db.executeStatement("select ID, title, state from tasks where userID = "+userid+" and title like '%"+terms+"%'");
+    let stmt = await db.executeStatement(
+        'select ID, title, state from tasks where userID = ? and title like ?',
+        [userid, `%${terms}%`]
+    );
     if (stmt.length > 0) {
         stmt.forEach(function(row) {
-            result += row.title+' ('+row.state+')<br />';
+            result += escapeHtml(row.title)+' ('+row.state+')<br />';
         });
     }
 

--- a/todo-list-node/user/tasklist.js
+++ b/todo-list-node/user/tasklist.js
@@ -1,4 +1,5 @@
 const db = require('../fw/db');
+const { escapeHtml } = require('../fw/utils');
 
 async function getHtml(req) {
     let html = `
@@ -14,13 +15,13 @@ async function getHtml(req) {
     `;
 
     let conn = await db.connectDB();
-    let [result, fields] = await conn.query('select ID, title, state from tasks where UserID = ' + req.cookies.userid);
+    let [result] = await conn.execute('select ID, title, state from tasks where UserID = ?', [req.cookies.userid]);
     console.log(result);
     result.forEach(function(row) {
         html += `
             <tr>
                 <td>`+row.ID+`</td>
-                <td class="wide">`+row.title+`</td>
+                <td class="wide">`+escapeHtml(row.title)+`</td>
                 <td>`+ucfirst(row.state)+`</td>
                 <td>
                     <a href="edit?id=`+row.ID+`">edit</a> | <a href="delete?id=`+row.ID+`">delete</a>


### PR DESCRIPTION
## Summary
- add HTML escaping helper
- secure DB helper with prepared statement support
- hash password comparison and use httpOnly cookies
- sanitize SQL statements across handlers
- restrict search provider and sanitize output

## Testing
- `npm audit`
- `node -c app.js`
- `node -c login.js`
- `node -c admin/users.js`
- `node -c edit.js`
- `node -c fw/db.js`
- `node -c fw/header.js`
- `node -c index.js`
- `node -c savetask.js`
- `node -c search.js`
- `node -c search/v2/index.js`
- `node -c user/tasklist.js`
- `node -c fw/utils.js`


------
https://chatgpt.com/codex/tasks/task_e_684fd05b2a288327a8b01d06571db748