### PR TITLE
Fix database save operations

### DIFF
--- a/todo-list-node/savetask.js
+++ b/todo-list-node/savetask.js
@@ -19,9 +19,9 @@ async function getHtml(req) {
         let userid = req.cookies.userid;
 
         if (taskId === ''){
-            stmt = db.executeStatement("insert into tasks (title, state, userID) values ('"+title+"', '"+state+"', '"+userid+"')");
+            stmt = await db.executeStatement("insert into tasks (title, state, userID) values ('"+title+"', '"+state+"', '"+userid+"')");
         } else {
-            stmt = db.executeStatement("update tasks set title = '"+title+"', state = '"+state+"' where ID = "+taskId);
+            stmt = await db.executeStatement("update tasks set title = '"+title+"', state = '"+state+"' where ID = "+taskId);
         }
 
         html += "<span class='info info-success'>Update successfull</span>";


### PR DESCRIPTION
## Summary
- make saving tasks wait for database operations to complete

## Testing
- `node test_savetask.js`

------
https://chatgpt.com/codex/tasks/task_e_684fd13ec3208327b6fa78d7af2d5045