### PR TITLE
Add password hashing and POST login

### DIFF
--- a/todo-list-node/app.js
+++ b/todo-list-node/app.js
@@ -84,6 +84,18 @@ app.get('/login', bruteForceProtection, async (req, res) => {
     }
 });
 
+// Login via POST with Brute-Force Protection
+app.post('/login', bruteForceProtection, async (req, res) => {
+    console.log('Content before');
+    let content = await login.handleLogin(req, res);
+    if (content.user.userid !== 0) {
+        login.startUserSession(res, content.user);
+    } else {
+        let html = await wrapContent(content.html, req);
+        res.send(html);
+    }
+});
+
 // Logout
 app.get('/logout', (req, res) => {
     req.session.destroy();

--- a/todo-list-node/docker/db/m183_lb2.sql
+++ b/todo-list-node/docker/db/m183_lb2.sql
@@ -133,8 +133,8 @@ insert into roles (ID, title) values (1, 'Admin');
 
 
 insert into users (ID, username, password, mfa_enabled, mfa_secret) values
-(1, 'admin1', 'Awesome.Pass34', 1, 'PJDDSTS2INCWWUTGKVWGIKBROVBWI4DQJJCE6UZ7OZPEC323FRQQ'),
-(2, 'user1', 'Amazing.Pass23', 0, NULL);
+(1, 'admin1', '$2b$10$eVdQHPHtZoa6HzzDJziEFe58AZMFjDTqfDO8Z5kTA4xUCW.5TlLmK', 1, 'PJDDSTS2INCWWUTGKVWGIKBROVBWI4DQJJCE6UZ7OZPEC323FRQQ'),
+(2, 'user1', '$2b$10$99FkJ.3iTpI9IhBM.AlBhuPuTGr2BIE2keDgjJNp3OJfFoLvdPwnS', 0, NULL);
 
 insert into permissions(ID, userID, roleID) values(null, 1, 1);
 insert into permissions(ID, userID, roleID) values(null, 2, 2);

--- a/todo-list-node/fw/bf-protection.js
+++ b/todo-list-node/fw/bf-protection.js
@@ -45,7 +45,7 @@ function recordFailure(req) {
   }
   attempts[ip] = entry;
 
-  const username = req.query?.username || '-';
+  const username = req.body?.username || req.query?.username || '-';
   logFailed(ip, username);
 }
 

--- a/todo-list-node/login.js
+++ b/todo-list-node/login.js
@@ -7,9 +7,9 @@ async function handleLogin(req, res) {
     let msg = '';
     let user = { username: '', userid: 0 };
 
-    const username = req.query.username;
-    const password = req.query.password;
-    const mfaCode  = req.query.mfaCode;
+    const username = req.body.username || req.query.username;
+    const password = req.body.password || req.query.password;
+    const mfaCode  = req.body.mfaCode  || req.query.mfaCode;
 
     if (typeof username !== 'undefined' && typeof password !== 'undefined') {
         console.log('Validating login for', username);
@@ -108,7 +108,7 @@ function getHtml(showMfa, username = '', password = '') {
     if (showMfa) {
         return `
         <h2>Enter MFA Code</h2>
-        <form method="get" action="/login">
+        <form method="post" action="/login">
             <input type="hidden" name="username" value="${username}">
             <input type="hidden" name="password" value="${password}">
             <div class="form-group">
@@ -122,14 +122,14 @@ function getHtml(showMfa, username = '', password = '') {
     }
     return `
     <h2>Login</h2>
-    <form id="form" method="get" action="/login">
+    <form id="form" method="post" action="/login">
         <div class="form-group">
             <label for="username">Username</label>
             <input type="text" class="form-control size-medium" name="username" id="username" value="${username}">
         </div>
         <div class="form-group">
             <label for="password">Password</label>
-            <input type="text" class="form-control size-medium" name="password" id="password" value="${password}">
+            <input type="password" class="form-control size-medium" name="password" id="password" value="${password}">
         </div>
         <div class="form-group">
             <input id="submit" type="submit" class="btn size-auto" value="Login" />


### PR DESCRIPTION
## Summary
- hash sample passwords in SQL seed data
- read credentials from POST body when logging in
- use POST forms with password type fields
- support POST login route
- log brute-force attempts with POST data

## Testing
- `node todo-list-node/app.js` *(server starts)*

------
https://chatgpt.com/codex/tasks/task_e_684fd98970c8832782a935b711000219