### PR TITLE
Fix user1 password for login

### DIFF
--- a/todo-list-node/docker/db/m183_lb2.sql
+++ b/todo-list-node/docker/db/m183_lb2.sql
@@ -134,7 +134,7 @@ insert into roles (ID, title) values (1, 'Admin');
 
 insert into users (ID, username, password, mfa_enabled, mfa_secret) values
 (1, 'admin1', '$2b$10$eVdQHPHtZoa6HzzDJziEFe58AZMFjDTqfDO8Z5kTA4xUCW.5TlLmK', 1, 'PJDDSTS2INCWWUTGKVWGIKBROVBWI4DQJJCE6UZ7OZPEC323FRQQ'),
-(2, 'user1', '$2b$10$99FkJ.3iTpI9IhBM.AlBhuPuTGr2BIE2keDgjJNp3OJfFoLvdPwnS', 0, NULL);
+(2, 'user1', '$2b$10$VUGAWJHFeWCO82.jmaRrrej5DhNoXRmb9427hiIUsHWU6RYjC9T16', 0, NULL);
 
 insert into permissions(ID, userID, roleID) values(null, 1, 1);
 insert into permissions(ID, userID, roleID) values(null, 2, 2);


### PR DESCRIPTION
## Summary
- set the seed password hash for `user1` to match `Amazing.Pass23`

## Testing
- `npm test` *(fails: Missing script)*
- `npm start` *(fails: nodemon Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_684fe3953f68832792a7e179384296e8